### PR TITLE
fix: add tmp directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .vscode/
 vendor
 .idea
+tmp


### PR DESCRIPTION
Add tmp directory to .gitignore since MMU uses this directory for files output via CLI by default.