### PR TITLE
chore: bump gas adjustment amount

### DIFF
--- a/dispatcher/transaction/generator/estimator.go
+++ b/dispatcher/transaction/generator/estimator.go
@@ -11,7 +11,7 @@ import (
 )
 
 // gasAdjust is the amount to multiply estimated gas by to account for "headroom" for tx inclusion.
-const gasAdjust = 1.25
+const gasAdjust = 1.5
 
 type SimulationGasEstimator struct {
 	conn   *grpc.ClientConn


### PR DESCRIPTION
We provide some headroom for the gas in Tx but since neutron uses feemarket, we probably are safer to just provide a greater amount.

Eventually, gasAdjust should be a param in your config, but for now, leaving it like this and making a triage issue