### PR TITLE
fix: early quote error

### DIFF
--- a/market-indexer/coinmarketcap/indexer.go
+++ b/market-indexer/coinmarketcap/indexer.go
@@ -151,6 +151,9 @@ func (i *Indexer) CacheQuotes(ctx context.Context, ids []int64) error {
 	return nil
 }
 
+// Quotes fetches the QuoteData for the given CMC IDs and returns them as a map.
+// If a desired ID is not returned, we fall back to individually fetch the data for the ID,
+// and return an error if that fails.
 func (i *Indexer) Quotes(ctx context.Context, ids []int64) (map[int64]QuoteData, error) {
 	i.logger.Debug("fetching quote data", zap.Any("cmc ids", ids))
 


### PR DESCRIPTION
Closes CON-1981

Add a fallback path to query the ID individually if it is somehow not seen in the response.

This error has been seen a few times from coinmarketcap, indicating an error from their end (if you retry, it ends up resolving).  In the case where we fail the individual query, it is reasonable to fail and surface the error from CMC.