### PR TITLE
fix: use `connect` instead of `slinky` for dydx devote

### DIFF
--- a/local/config-dydx-devnet.json
+++ b/local/config-dydx-devnet.json
@@ -390,7 +390,7 @@
     "rest_address": "https://validator.v4staging.dydx.exchange:1317",
     "dydx": true,
     "chain_id": "dydxprotocol-testnet",
-    "version": "slinky",
+    "version": "connect",
     "prefix": "dydx"
   }
 }


### PR DESCRIPTION
Closes CON-1985