### PR TITLE
Add WithQueryParam and only get spot markets from CMC

### DIFF
--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -36,6 +36,14 @@ func WithJSONAccept() GetOptions {
 	}
 }
 
+func WithQueryParam(key, value string) GetOptions {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		q.Add(key, value)
+		r.URL.RawQuery = q.Encode()
+	}
+}
+
 // GetWithContext performs a Get request with the context provided.
 func (c *Client) GetWithContext(ctx context.Context, url string, opts ...GetOptions) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/market-indexer/coinmarketcap/client.go
+++ b/market-indexer/coinmarketcap/client.go
@@ -136,6 +136,7 @@ func (h *httpClient) ExchangeMarkets(ctx context.Context, exchange int) (Exchang
 	opts := []http.GetOptions{
 		http.WithHeader("X-CMC_PRO_API_KEY", h.apiKey),
 		http.WithJSONAccept(),
+		http.WithQueryParam("category", "spot"),
 	}
 
 	resp, err := h.client.GetWithContext(ctx, fmt.Sprintf(EndpointExchangeMarkets, exchange), opts...)


### PR DESCRIPTION
Currently `ExchangeMarkets` request returns exchange markets for spot, perpetuals, and futures. This contributes to overwriting in the provider markets map with undesired data. We want only the spot market data.