### PR TITLE
Fix generate comparison

### DIFF
--- a/generator/types/types.go
+++ b/generator/types/types.go
@@ -142,10 +142,6 @@ func Compare(a, b Feed) bool {
 		return a.CMCInfo.BaseRank > b.CMCInfo.BaseRank
 	}
 
-	if a.CMCInfo.QuoteRank != b.CMCInfo.QuoteRank {
-		return a.CMCInfo.QuoteRank > b.CMCInfo.QuoteRank
-	}
-
 	if a.LiquidityInfo.TotalLiquidity() != b.LiquidityInfo.TotalLiquidity() {
 		return a.LiquidityInfo.TotalLiquidity() < b.LiquidityInfo.TotalLiquidity()
 	}

--- a/generator/types/types_test.go
+++ b/generator/types/types_test.go
@@ -195,6 +195,25 @@ func TestCompare(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "quote rank is not considered in comparison",
+			a: types.Feed{
+				CMCInfo: mmutypes.NewCoinMarketCapInfo(0, 0, 1, 10),
+				LiquidityInfo: mmutypes.LiquidityInfo{
+					NegativeDepthTwo: 10,
+					PositiveDepthTwo: 10,
+				},
+			},
+			b: types.Feed{
+				CMCInfo: mmutypes.NewCoinMarketCapInfo(0, 0, 1, 1),
+				LiquidityInfo: mmutypes.LiquidityInfo{
+					NegativeDepthTwo: 0,
+					PositiveDepthTwo: 0,
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
 			name: "mismatched currency still returns",
 			a: types.Feed{
 				Ticker: mmtypes.Ticker{CurrencyPair: connecttypes.CurrencyPair{


### PR DESCRIPTION
Don't use QuoteRank to compare feeds because this leads to worse results. For example, it preferences XMR-BTC for Kucoin instead of XMR-USDT because BTC has a lower CMC rank than USDT even though XMR-USDT has higher liquidity and volume